### PR TITLE
Fix for multi-channel MIDI out

### DIFF
--- a/src/main/PluginProcessor.cpp
+++ b/src/main/PluginProcessor.cpp
@@ -264,7 +264,7 @@ void VmpcAudioProcessor::processMidiOut(juce::MidiBuffer& midiMessages)
         juce::MidiMessage juceMsg;
         bool compatibleMsg = false;
 
-        if (msg->getStatus() == ShortMessage::NOTE_ON || msg->getStatus() == ShortMessage::NOTE_OFF)
+        if (msg->getCommand() == ShortMessage::NOTE_ON || msg->getCommand() == ShortMessage::NOTE_OFF)
         {
             juce::uint8 velo = (juce::uint8) msg->getData2();
 


### PR DESCRIPTION
### Problem description:
If track MIDI output is switched to any channel/device other than 01, there is no MIDI output from vMPC

### Technical cause:
Before being piped to Plugin MIDI output MIDI messages are checked for compatibility. However, the check is done against the MIDI status byte, which actually has both channel number and command code nibbles. 

For transport / sync messages it does not really matter, since they are conceptually omni-channel. But for note messages, the expression:  
```cpp
msg->getStatus() == ShortMessage::NOTE_ON
```
Is only true, when messages comes from channel 0. 

### Solution:
Use MIDI command nibble when checking if it was a MIDI on/off event.

Thank you